### PR TITLE
Addressing #8

### DIFF
--- a/Matlab_test_utils.m
+++ b/Matlab_test_utils.m
@@ -32,8 +32,7 @@ else
 end
 
 command='cmake --help';
-pattern='Specify a source directory';
-if(Matlab_test_utils_test_if_command_available(command,pattern))
+if(Matlab_test_utils_test_if_command_available(command))
     disp('cmake [OK]');
 else
     disp('Error cmake is not available [NOT OK]');

--- a/Matlab_test_utils.m
+++ b/Matlab_test_utils.m
@@ -12,7 +12,7 @@ minor_version = cell2mat(version_split(2));
 if((major_version<3) || (major_version==3 && minor_version<2))
     disp('unsupported casadi version, install 3.2.x or higher');
 else
-    disp(['casadi version ' version_casadi '[OK]']);
+    disp(['casadi version ' version_casadi ' [OK]']);
 end
 
 command = 'gcc';

--- a/Matlab_test_utils_test_if_command_available.m
+++ b/Matlab_test_utils_test_if_command_available.m
@@ -5,7 +5,9 @@ function [ available ] = Matlab_test_utils_test_if_command_available( command,pa
     % -
     [cmd_exec_status ,cmdout] = system(command);
     if nargin >= 2
-        available = contains(cmdout,pattern);
+        %Note: `contains` was introduced in MATLAB 2016b and it is not 
+        %supported by previous versions, that's why we have to use:
+        available = ~isempty(strfind(cmdout,pattern)); 
     else
         available = cmd_exec_status == 0;
     end

--- a/Matlab_test_utils_test_if_command_available.m
+++ b/Matlab_test_utils_test_if_command_available.m
@@ -5,7 +5,7 @@ function [ available ] = Matlab_test_utils_test_if_command_available( command,pa
     % -
     [cmd_exec_status ,cmdout] = system(command);
     if nargin >= 2
-        available = ~isempty(strfind(cmdout,pattern));
+        available = contains(cmdout,pattern);
     else
         available = cmd_exec_status == 0;
     end

--- a/Matlab_test_utils_test_if_command_available.m
+++ b/Matlab_test_utils_test_if_command_available.m
@@ -3,7 +3,11 @@ function [ available ] = Matlab_test_utils_test_if_command_available( command,pa
     % contains a specific pattern
     % - command contains the command
     % -
-    [~,cmdout] = system(command);
-    available = ~isempty(strfind(cmdout,pattern));
+    [cmd_exec_status ,cmdout] = system(command);
+    if nargin >= 2
+        available = ~isempty(strfind(cmdout,pattern));
+    else
+        available = cmd_exec_status == 0;
+    end
 end
 


### PR DESCRIPTION
Using system execution status to test whether a system command exists. Fixes issue https://github.com/kul-forbes/nmpc-codegen/issues/8.

Note: I should have created the issue in this repository. Sorry about that.