### PR TITLE
Using absolute paths instead of relative ones

### DIFF
--- a/demos/prepare_demo_trailer.m
+++ b/demos/prepare_demo_trailer.m
@@ -4,7 +4,8 @@ function trailer_controller = prepare_demo_trailer( controller_folder_name,step_
 %   enviroment. (output location is repo/test_controller_builds/demo_controller_matlab)
 
     % generate static files
-    trailer_controller_output_location =  ['../test_controller_builds/' controller_folder_name];
+    rootdir = get_nmpc_codegen_matlab_rootdir();    
+    trailer_controller_output_location =  fullfile(rootdir, 'test_controller_builds', controller_folder_name);
     nmpccodegen.tools.Bootstrapper.bootstrap(trailer_controller_output_location, true);
 
     % get example model from lib

--- a/get_nmpc_codegen_matlab_rootdir.m
+++ b/get_nmpc_codegen_matlab_rootdir.m
@@ -1,0 +1,4 @@
+function rootdir = get_nmpc_codegen_matlab_rootdir()
+rootdir = which('get_nmpc_codegen_matlab_rootdir');
+tokens = strsplit(rootdir, 'get_nmpc_codegen_matlab_rootdir.m');
+rootdir = tokens{1};


### PR DESCRIPTION
I introduced a function called `get_nmpc_codegen_matlab_rootdir` which returns the path to the root directory of `nmpc-codegen-matlab`.

It's unclear to me how to obtain the root directory of `nmpc-codegen`.

One idea is that if the user has got the code from github using `git clone --recursive`, then the `nmpc-codegen` is a submodule which is found in `{nmpc-codegen-matlab-rootdir}/kernel/`.